### PR TITLE
Api provides visitor to view articles by category

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :development, :test do
   gem 'shoulda-matchers'
   gem 'factory_bot_rails'
   gem 'pry-byebug'
-  gem 'coveralls',  require:  false
+  gem 'coveralls', require: false
 end
 
 group :development do

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,3 +1,4 @@
 class Article < ApplicationRecord
-  validates_presence_of :title, :lead, :content
+  validates_presence_of :title, :lead, :content, :category
+  enum category: [:latest_news, :tech, :food, :sports, :culture]
 end

--- a/app/serializers/article_show_serializer.rb
+++ b/app/serializers/article_show_serializer.rb
@@ -1,3 +1,3 @@
 class ArticleShowSerializer < ActiveModel::Serializer
-  attributes :id, :title, :lead, :content
+  attributes :id, :title, :lead, :content, :category
 end

--- a/app/serializers/articles_serializer.rb
+++ b/app/serializers/articles_serializer.rb
@@ -1,3 +1,3 @@
 class ArticlesSerializer < ActiveModel::Serializer
-  attributes :id, :title, :lead
+  attributes :id, :title, :lead, :category
 end

--- a/db/migrate/20200321101003_add_category_to_articles.rb
+++ b/db/migrate/20200321101003_add_category_to_articles.rb
@@ -1,0 +1,5 @@
+class AddCategoryToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :category, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_19_100121) do
+ActiveRecord::Schema.define(version: 2020_03_21_101003) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_03_19_100121) do
     t.string "title"
     t.string "lead"
     t.text "content"
+    t.integer "category", default: 0
   end
 
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
    title {'This is an article'} 
    lead {'This is an article lead'}
    content {'This is article content'}
+   category {'latest_news'}
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe Article, type: :model do
     it {is_expected.to have_db_column :title}
     it {is_expected.to have_db_column :lead}
     it {is_expected.to have_db_column :content}
+    it {is_expected.to have_db_column :category}
   end
 
   describe 'Validations' do
     it {is_expected.to validate_presence_of :title}
     it {is_expected.to validate_presence_of :lead}
     it {is_expected.to validate_presence_of :content}
+    it {is_expected.to validate_presence_of :category}
   end
   
   describe 'Factory' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,4 @@
-require  'coveralls'
+require 'coveralls'
 Coveralls.wear_merged!('rails')
 
 ENV['RAILS_ENV'] ||= 'test'

--- a/spec/requests/api/visitor_can_see_details_of_an_article_spec.rb
+++ b/spec/requests/api/visitor_can_see_details_of_an_article_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Api::ArticlesController, type: :request do
     end
 
     it 'should return title articles' do
-      binding.pry
       expect(response_json['article']['title']).to eq 'Article Title'
     end
 

--- a/spec/requests/api/visitor_can_see_details_of_an_article_spec.rb
+++ b/spec/requests/api/visitor_can_see_details_of_an_article_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Api::ArticlesController, type: :request do
     end
 
     it 'should return title articles' do
+      binding.pry
       expect(response_json['article']['title']).to eq 'Article Title'
     end
 

--- a/spec/requests/api/visitor_can_see_details_of_an_article_spec.rb
+++ b/spec/requests/api/visitor_can_see_details_of_an_article_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Api::ArticlesController, type: :request do
   describe 'GET /article/1 successfully' do
-    let!(:articles) { create(:article, title: 'Article Title', lead: 'At some point there will be something the read in the lead', content: 'Article content will go here for the user to read.') }
+    let!(:articles) { create(:article, title: 'Article Title', lead: 'At some point there will be something the read in the lead', content: 'Article content will go here for the user to read.', category: 'latest_news') }
     before do
       get "/api/articles/#{articles.id}"
     end
@@ -21,6 +21,10 @@ RSpec.describe Api::ArticlesController, type: :request do
 
     it 'should return content articles' do
       expect(response_json['article']['content']).to eq 'Article content will go here for the user to read.'
+    end
+
+    it 'should return article category' do
+      expect(response_json['article']['category']).to eq 'latest_news'
     end
   end
 end

--- a/spec/requests/api/visitor_can_see_details_of_an_article_spec.rb
+++ b/spec/requests/api/visitor_can_see_details_of_an_article_spec.rb
@@ -2,9 +2,9 @@
 
 RSpec.describe Api::ArticlesController, type: :request do
   describe 'GET /article/1 successfully' do
-    let!(:articles) { create(:article, title: 'Article Title', lead: 'At some point there will be something the read in the lead', content: 'Article content will go here for the user to read.') }
+    let!(:article) { create(:article, title: 'Article Title', lead: 'At some point there will be something the read in the lead', content: 'Article content will go here for the user to read.') }
     before do
-      get "/api/articles/#{articles.id}"
+      get "/api/articles/#{article.id}"
     end
 
     it 'should return a 200 response' do


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171841463)
## User Story
```
As a visitor
In order to find an article I want to read
I would like to be able to view articles by category
```
## Changes proposed in this pull request:
* Adds category attribute for article model, serializer and factory bot
* Adds RSpec tests for category in showing a specific article to a visitor
* Adds RSpec test for category in Articles Model
## What I have learned working on this feature:
* How to use enums in Rails
## Packages/Gems added
N/A
