### PR TITLE
API allows journalists to create article

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -17,6 +17,8 @@ class Api::ArticlesController < ApplicationController
     article = Article.create(article_params)
     if article.persisted?
       render json: {message: 'Your article was successfully created'}
+    else
+      render json: { error: 'Something went wrong' }, status: 422
     end
   end
 

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -12,11 +12,11 @@ class Api::ArticlesController < ApplicationController
     article = Article.find(params[:id])
     render json: article, serializer: ArticleShowSerializer
   end
-  
+
   def create
     article = Article.create(article_params)
     if article.persisted?
-      render json: {message: 'Your article was successfully created'}
+      render json: { message: 'Your article was successfully created' }
     else
       render json: { error: 'Something went wrong' }, status: 422
     end

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -12,4 +12,17 @@ class Api::ArticlesController < ApplicationController
     article = Article.find(params[:id])
     render json: article, serializer: ArticleShowSerializer
   end
+  
+  def create
+    article = Article.create(article_params)
+    if article.persisted?
+      render json: {message: 'Your article was successfully created'}
+    end
+  end
+
+  private
+
+  def article_params
+    params.require(:article).permit(:title, :lead, :content, :category)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   namespace :api do 
-    resources :articles, only: [:index, :show]
+    resources :articles, only: [:index, :show, :create]
   end
 end

--- a/spec/requests/api/journalist_can_create_article_spec.rb
+++ b/spec/requests/api/journalist_can_create_article_spec.rb
@@ -23,4 +23,27 @@ let(:headers) { { HTTP_ACCEPT:'application/json' } }
       expect(response_json['message']).to eq 'Your article was successfully created'
     end
   end
+
+  describe 'with valid params' do
+    before do
+      post '/api/articles',
+      params: {
+        article: {
+          title:"",
+          lead: "",
+          content: "",
+          category: "latest_news"
+        }
+      },
+      headers: headers
+    end
+
+    it 'returns 422 response' do
+      expect(response.status).to eq 422
+    end
+
+    it 'returns an unsuccessful message' do
+      expect(response_json['error']).to eq 'Something went wrong'
+    end
+  end
 end

--- a/spec/requests/api/journalist_can_create_article_spec.rb
+++ b/spec/requests/api/journalist_can_create_article_spec.rb
@@ -1,18 +1,18 @@
 RSpec.describe 'POST /articles', type: :request do
-let(:headers) { { HTTP_ACCEPT:'application/json' } }
+  let(:headers) { { HTTP_ACCEPT: 'application/json' } }
 
   describe 'with valid params' do
     before do
       post '/api/articles',
-      params: {
-        article: {
-          title:"New Car",
-          lead: "It's a Berlingo",
-          content: "Oliver hates it",
-          category: "latest_news"
-        }
-      },
-      headers: headers
+        params: {
+          article: {
+            title: 'New Car',
+            lead: "It's a Berlingo",
+            content: 'Oliver hates it',
+            category: 'latest_news'
+          }
+        },
+        headers: headers
     end
 
     it 'returns 200 response' do
@@ -27,15 +27,15 @@ let(:headers) { { HTTP_ACCEPT:'application/json' } }
   describe 'with valid params' do
     before do
       post '/api/articles',
-      params: {
-        article: {
-          title:"",
-          lead: "",
-          content: "",
-          category: "latest_news"
-        }
-      },
-      headers: headers
+        params: {
+          article: {
+            title: '',
+            lead: '',
+            content: '',
+            category: 'latest_news'
+          }
+        },
+        headers: headers
     end
 
     it 'returns 422 response' do

--- a/spec/requests/api/journalist_can_create_article_spec.rb
+++ b/spec/requests/api/journalist_can_create_article_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe 'POST /articles', type: :request do
+let(:headers) { { HTTP_ACCEPT:'application/json' } }
+
+  describe 'with valid params' do
+    before do
+      post '/api/articles',
+      params: {
+        article: {
+          title:"New Car",
+          lead: "It's a Berlingo",
+          content: "Oliver hates it",
+          category: "latest_news"
+        }
+      },
+      headers: headers
+    end
+
+    it 'returns 200 response' do
+      expect(response.status).to eq 200
+    end
+
+    it 'returns a success message' do
+      expect(response_json['message']).to eq 'Your article was successfully created'
+    end
+  end
+end


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171820797)
## User Story
```
As a journalist,
In order to write articles
I would like to be able to have an article creation form
```
## Changes proposed in this pull request:
* Adds create action to Article Controller
* Adds response to client for both happy and sad path
* Writes spec for both happy and sad path of the create action
## What I have learned working on this feature:
* Got better understanding of how to deal with sad path depending on the implementation of the API