### PR TITLE
Update API so Visitor can see Article Images with Index Action

### DIFF
--- a/app/serializers/articles_serializer.rb
+++ b/app/serializers/articles_serializer.rb
@@ -1,3 +1,14 @@
 class ArticlesSerializer < ActiveModel::Serializer
-  attributes :id, :title, :lead, :category
+  include Rails.application.routes.url_helpers
+  
+  attributes :id, :title, :lead, :category, :image
+
+  def image
+    return nil unless object.image.attached?
+    if Rails.env.test?
+      rails_blob_url(object.image)
+    else
+      object.image.service_url(expires_in: 1.hour, disposition: 'inline')
+    end
+  end
 end


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171995059)
## User Story
```
As a visitor
In order to figure out which article to read
I would like to see an article image before selecting a specific article
```
## Changes proposed in this pull request:
* Adds same updates to article serialiser for sending off an image as in the show serialiser
