### PR TITLE
Api allows articles to be set as premium

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -25,7 +25,7 @@ class Api::ArticlesController < ApplicationController
   private
 
   def article_params
-    params.require(:article).permit(:title, :lead, :content, :category)
+    params.require(:article).permit(:title, :lead, :content, :category, :premium)
   end
 
   def attach_image(article)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,5 +1,5 @@
 class Article < ApplicationRecord
   has_one_attached :image
-  validates_presence_of :title, :lead, :content, :category
+  validates_presence_of :title, :lead, :content, :category, :premium
   enum category: [:latest_news, :tech, :food, :sports, :culture]
 end

--- a/app/serializers/article_show_serializer.rb
+++ b/app/serializers/article_show_serializer.rb
@@ -1,7 +1,7 @@
 class ArticleShowSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
   
-  attributes :id, :title, :lead, :content, :category, :image
+  attributes :id, :title, :lead, :content, :category, :image, :premium 
 
   def image
     return nil unless object.image.attached?

--- a/app/serializers/articles_serializer.rb
+++ b/app/serializers/articles_serializer.rb
@@ -1,7 +1,7 @@
 class ArticlesSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
   
-  attributes :id, :title, :lead, :category, :image
+  attributes :id, :title, :lead, :category, :image, :premium
 
   def image
     return nil unless object.image.attached?

--- a/db/migrate/20200328133706_add_premium_to_article.rb
+++ b/db/migrate/20200328133706_add_premium_to_article.rb
@@ -1,0 +1,5 @@
+class AddPremiumToArticle < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :premium, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_24_135241) do
+ActiveRecord::Schema.define(version: 2020_03_28_133706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2020_03_24_135241) do
     t.string "lead"
     t.text "content"
     t.integer "category", default: 0
+    t.boolean "premium"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,5 +26,3 @@ lead: "As people continue to avoid leaving home as much as possible, new creativ
 content: "We are in a time of Rennasaince for the home chef as people continue to be reticient to leave their home unless absolutely necessary. People are finally finding uses for the mostly empty bags of frozen vegetables, that last half cup of flour, and only having enough pasta for half a meal. They are taking the normally ignored food items that never seem to make their way to a plate, and creating wonderfully diverse, if sometimes inedible, creations that are delighting the world. Stay tuned for an exclusive of some of these wonderfully unexpected and bizarre meals.",
 premium: "true"
 
-User.create email: "user@mail.com",
-password: "password"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,30 @@
-Article.create title: 'Article Title', lead: 'At some point there will be something the read in the lead', content: 'Article content will go here for the user to read.'
-Article.create title: 'Coronavirus in Sweden', lead: 'We are all in quarentine', content: 'We are all mad here'
-Article.create title: 'Thomas Got a New Car', lead: 'He bought it to comfort himself', content: 'And now he wants a third car, that he found on Blocket.'
+Article.create title: "Article Title", category: "sports", lead: "At some point there will be something the read in the lead",
+content: "Article content will go here for the user to read. If they so choose to actually read. And not just look at the title and picture. And if they do in fact make it this far in the text, surprise! You win a prize! Yes indeed folks, you get a prize for reading this far. And what is this said prize? Well, it is that there are even more articles on this site for you to read! Congrats and have fun read more of our wonderful content!",
+premium: "true"
+
+Article.create title: "Coronavirus in Sweden",
+category: "latest_news",
+lead: "We are all in quarentine",
+content: "We are all mad here. That quote from the Mad Hatter in Alice in Wonderland has never been more true than now. We are experiencing a wave of maddness as the quarentine continues for people across the globe. People in Italy have been reported to actually talk to their neighbors, playing music for the street and even group calisthenics on the patio. These are indeed scary times. As we move forward into an uncertain future, we have got to wonder, what will the Italians do next.",
+premium: "false"
+
+Article.create title: "Thomas Got a New Car",
+category: "culture",
+lead: "He bought it to comfort himself",
+content: "On Wednesday of last we, we here at Newsroom 1 were informed that Thomas Ochman had bought a new car. And not just any car but a Berlingo. His son, Oliver, was reported to have shaken his head in sadness when he heard the news, questioning why his father needed another car. And yet, later that same day we also learned that Mr. Ochman wants a third car. And not just any car, but a blank that he found on Blocket. The big questions now are: will he get it and how will Oliver react?",
+premium: "true"
+
+Article.create title: "Craft Academy Heading for the Stars",
+category: "tech",
+lead: "This little start up is up and coming as their bootcamp programs gains more presteige.",
+content: "Craft Academy has been around for a few years now and have been consistently producing Software Engineers of exceptional quality. All their students have been a beacon of what a bootcamps can be and the quality of education they can produce. As yet another cohort is about to emerge, we are excited to get these young padawon coders into the market where they can blossom into the experienced coders we need to keep up in these modern times.",
+premium: "false"
+
+Article.create title: "The Delicacies Created Because of Coronavirus",
+category: "food",
+lead: "As people continue to avoid leaving home as much as possible, new creative levels are being reached in the kitchen.",
+content: "We are in a time of Rennasaince for the home chef as people continue to be reticient to leave their home unless absolutely necessary. People are finally finding uses for the mostly empty bags of frozen vegetables, that last half cup of flour, and only having enough pasta for half a meal. They are taking the normally ignored food items that never seem to make their way to a plate, and creating wonderfully diverse, if sometimes inedible, creations that are delighting the world. Stay tuned for an exclusive of some of these wonderfully unexpected and bizarre meals.",
+premium: "true"
+
+User.create email: "user@mail.com",
+password: "password"

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     lead {'This is an article lead'}
     content {'This is article content'}
     category {'latest_news'}
+    premium { true }
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_db_column :lead }
     it { is_expected.to have_db_column :content }
     it { is_expected.to have_db_column :category }
+    it { is_expected.to have_db_column :premium }
   end
 
   describe "Validations" do
@@ -12,6 +13,7 @@ RSpec.describe Article, type: :model do
     it { is_expected.to validate_presence_of :lead }
     it { is_expected.to validate_presence_of :content }
     it { is_expected.to validate_presence_of :category }
+    it { is_expected.to validate_presence_of :premium }
   end
 
   describe "Factory" do

--- a/spec/requests/api/journalist_can_create_article_spec.rb
+++ b/spec/requests/api/journalist_can_create_article_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe 'POST /articles', type: :request do
             lead: "It's a Berlingo",
             content: 'Oliver hates it',
             category: 'latest_news',
-            image: image
+            image: image,
+            premium: "true"
           },
         },
         headers: headers


### PR DESCRIPTION

# [PT Story](https://www.pivotaltracker.com/story/show/171977442)
## User Story
```
As a user 
In order to access premium content
I would like to see premium content
```
## Changes proposed in this pull request:
* Adds premium attribute to article model 
* Modifies Rspec tests for premium article attribute

## What I have learned working on this feature:
* Using rails generate command to add columns to an existing data table

