### PR TITLE
API allows journalist can log in

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,5 +3,6 @@ extend Devise::Models
   devise :database_authenticatable, :registerable,
     :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
-  enum role: [:user]
+  validates_presence_of :role
+  enum role: [:user, :journalist]
 end

--- a/db/migrate/20200403075915_add_role_to_users.rb
+++ b/db/migrate/20200403075915_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :role, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_28_163747) do
+ActiveRecord::Schema.define(version: 2020_04_03_075915) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,7 +67,8 @@ ActiveRecord::Schema.define(version: 2020_03_28_163747) do
     t.string "last_sign_in_ip"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "premium_user", default: false
+    t.boolean "premium_user"
+    t.integer "role", default: 0
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(version: 2020_04_03_075915) do
     t.string "last_sign_in_ip"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "premium_user"
+    t.boolean "premium_user", default: false
     t.integer "role", default: 0
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,5 +26,6 @@ lead: "As people continue to avoid leaving home as much as possible, new creativ
 content: "We are in a time of Rennasaince for the home chef as people continue to be reticient to leave their home unless absolutely necessary. People are finally finding uses for the mostly empty bags of frozen vegetables, that last half cup of flour, and only having enough pasta for half a meal. They are taking the normally ignored food items that never seem to make their way to a plate, and creating wonderfully diverse, if sometimes inedible, creations that are delighting the world. Stay tuned for an exclusive of some of these wonderfully unexpected and bizarre meals.",
 premium: true
 
-User.create email: 'user@mail.com', password: 'password', premium_user: false
-User.create email: 'premium@mail.com', password: 'password', premium_user: true
+User.create email: 'user@mail.com', password: 'password', premium_user: false, role: 'user'
+User.create email: 'premium@mail.com', password: 'password', premium_user: true, role: 'user'
+User.create email: 'journalist@mail.com', password: 'password', premium_user: true, role: 'journalist'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
     password { "password" }
     password_confirmation { "password" }
     premium_user { false }
+    role { 'user' }
+    factory :journalist do
+      role { 'journalist' } 
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe User, type: :model do
 
   describe "Validations" do
     it { is_expected.to validate_presence_of :email }
+    it { is_expected.to validate_presence_of :role }
     it { is_expected.to validate_confirmation_of :password }
-    it { is_expected.to validate_confirmation_of :role }
 
     context "should not have an invalid email address" do
       emails = ["asdf@ ds.com", "@example.com", "test me @yahoo.com",

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_db_column :email }
     it { is_expected.to have_db_column :tokens }
     it { is_expected.to have_db_column :premium_user }
+    it { is_expected.to have_db_column :role }
   end
 
   describe "Validations" do
     it { is_expected.to validate_presence_of :email }
     it { is_expected.to validate_confirmation_of :password }
+    it { is_expected.to validate_confirmation_of :role }
 
     context "should not have an invalid email address" do
       emails = ["asdf@ ds.com", "@example.com", "test me @yahoo.com",

--- a/spec/requests/api/journalist_can_create_article_spec.rb
+++ b/spec/requests/api/journalist_can_create_article_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe 'POST /articles', type: :request do
-  let(:headers) { { HTTP_ACCEPT: 'application/json' } }
-
+  let(:user) { create(:user, role: 'journalist') }
+  let(:credentials) { user.create_new_auth_token }
+  let(:headers) { { HTTP_ACCEPT: "application/json" }.merge!(credentials) }
+   
   let(:image) do
     {
       type: 'application/jpg',

--- a/spec/requests/api/sessions_spec.rb
+++ b/spec/requests/api/sessions_spec.rb
@@ -2,13 +2,13 @@
 
 RSpec.describe "POST /api/auth/sign_in", type: :request do
   let(:headers) { { HTTP_ACCEPT: "application/json" } }
-  let(:user) { create(:user) }
+  let(:user) { create(:user, role: 'user') }
   let(:expected_response) do
     {
       "data" => {
         "id" => user.id, "uid" => user.email, "email" => user.email,
         "provider" => "email", "allow_password_change" => false,
-        "premium_user" => user.premium_user,
+        "premium_user" => user.premium_user, "role" => "user"
       },
     }
   end


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171936153)
## User Story
```
As a journalist
In order to access the articles I have written
I would like to be able to log in
```

## Changes proposed in this pull request:
* Adds RSpec test for journalist can login
* Updates controller for article creation so only journalists can crate article
* Adds enum roles for user model to validate the presence of :role
* Updates RSpec session test to use roles for user and journalist
* Updates Factory Bot to create a user and journalist
* Updates seed file with user and journalist roles

## What we have learned working on this feature:
* Refreshed knowledge about user roles and conditioning actions on authentication
* How to create multiple user for a test to test user role restriction
